### PR TITLE
Updated simtool notebook

### DIFF
--- a/simtool/polymerxtal.ipynb
+++ b/simtool/polymerxtal.ipynb
@@ -35,13 +35,13 @@
     "%%yaml INPUTS\n",
     "\n",
     "polymer_type:\n",
-    "    type: Text\n",
+    "    type: Choice\n",
     "    value: PAN\n",
     "    description: Select the polymer type.\n",
     "    options: [PAN, PE, PP, PS, POM, PTFE, PVC]\n",
     "\n",
     "helicity:\n",
-    "    type: Text\n",
+    "    type: Choice\n",
     "    value: Helix 2*3/1\n",
     "    description: Select the helicity of the polymer chain.\n",
     "    options: [Helix 2*3/1, Helix 2*2/1, Helix 2*1/1]\n",
@@ -54,13 +54,13 @@
     "    max: 100\n",
     "\n",
     "tacticity:\n",
-    "    type: Text\n",
+    "    type: Choice\n",
     "    value: isotactic\n",
     "    description: Select the tacticity of the polymer chain.\n",
     "    options: [isotactic, atactic, syndiotactic, N/A]\n",
     "\n",
     "chiriality:\n",
-    "    type: Text\n",
+    "    type: Choice\n",
     "    value: right\n",
     "    description: Select the chiriality of the polymer chain.\n",
     "    options: [left, right, N/A]\n",
@@ -95,7 +95,7 @@
     "    value: True    \n",
     "\n",
     "ffield:\n",
-    "    type: Text\n",
+    "    type: Choice\n",
     "    value: Dreiding\n",
     "    description: Force field\n",
     "    options: [Dreiding, PCFF]\n",
@@ -108,7 +108,7 @@
     "    max: 2\n",
     "\n",
     "charge:\n",
-    "    type: Text\n",
+    "    type: Choice\n",
     "    value: Gasteiger\n",
     "    description: Charge equilibration method\n",
     "    options: [Gasteiger]"
@@ -269,7 +269,7 @@
  "metadata": {
   "celltoolbar": "Tags",
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3.8",
    "language": "python",
    "name": "python3"
   },
@@ -283,7 +283,49 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.7"
+   "version": "3.8.10"
+  },
+  "toc": {
+   "base_numbering": 1,
+   "nav_menu": {},
+   "number_sections": true,
+   "sideBar": true,
+   "skip_h1_title": false,
+   "title_cell": "Table of Contents",
+   "title_sidebar": "Contents",
+   "toc_cell": false,
+   "toc_position": {},
+   "toc_section_display": true,
+   "toc_window_display": false
+  },
+  "varInspector": {
+   "cols": {
+    "lenName": 16,
+    "lenType": 16,
+    "lenVar": 40
+   },
+   "kernels_config": {
+    "python": {
+     "delete_cmd_postfix": "",
+     "delete_cmd_prefix": "del ",
+     "library": "var_list.py",
+     "varRefreshCmd": "print(var_dic_list())"
+    },
+    "r": {
+     "delete_cmd_postfix": ") ",
+     "delete_cmd_prefix": "rm(",
+     "library": "var_list.r",
+     "varRefreshCmd": "cat(var_dic_list()) "
+    }
+   },
+   "types_to_exclude": [
+    "module",
+    "function",
+    "builtin_function_or_method",
+    "instance",
+    "_Feature"
+   ],
+   "window_display": false
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Solves problem with Text - Options incompatibility by replacing the input type with "Choice" as per the newest sim2l library directive

## Description
Solves the incompatibility between Text input and options argument of the sim2l input definition. Currently, the nanoHUB GUI crashes with an error. This was documented in nanoHUB tickets # 401202 and # 413765

## Status
- [x] Ready to go